### PR TITLE
Fix 197x historic overlay's filter configuration

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -948,12 +948,14 @@ var config = {
 		},
 		{
 			group: 'Històric',
-			title: '1970',
-			query: '(nwr[~"name"~".*"]({{bbox}});node(w););out meta;',
+			title: '1970-1979',
+			query: '(nwr[~"^name:197[0-9]$"~"."]({{bbox}});node(w););out meta;',
 			iconSrc: imgSrc + 'base/circle.svg',
 			iconStyle: 'background-color:#714601',
 			style: function (feature) {
-				var name = feature.get('~name~.*') || '';
+				var key_regex = /^name:197[0-9]$/
+				var name_key = feature.getKeys().filter(function(t){return t.match(key_regex)}).pop() || "name"
+				var name = feature.get(name_key) || '';
 				var styles = {
 					'amenity': {
 						'parking': new ol.style.Style({
@@ -1168,7 +1170,7 @@ var config = {
 			iconSrc: imgSrc + 'base/circle.svg',
 			iconStyle: 'background-color:#714601',
 			style: function (feature) {
-				var name = feature.get('~"^name:197.$"~"."') || '';	
+				var name = feature.get('name~"^197.$"') || '';			
 				var styles = {
 					'amenity': {
 						'parking': new ol.style.Style({


### PR DESCRIPTION
The feature's "get" method is plain, so the feature keys have to be explored to find the right one for the name.

`key_regex` contains the regex to apply to find the right key, if the filtering returns nothing it'll use "name" instead (included in case this is copy-pasted somewhere else).

Not all browsers support expressing the inline regex; tested with Firefox 80.